### PR TITLE
处理32位读写的问题

### DIFF
--- a/hw/ats/riscv_lite_executor.c
+++ b/hw/ats/riscv_lite_executor.c
@@ -46,26 +46,26 @@ static uint64_t riscv_lite_executor_read_64bit(RISCVLiteExecutor *lite_executor,
             if(ps_addr < PS_MEMBUF_MMIO_OFFSET) {
                 // Priority scheduler control field
                 unsigned control_addr = ps_addr;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler control field, process %d, inner addr 0x%04x", addr, process_index, control_addr);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Priority scheduler control field, process %d, inner addr 0x%04x", addr, process_index, control_addr);
                 return 0;
             }
             else if(ps_addr < PS_DEQUEUE_MMIO_OFFSET) {
                 // Priority scheduler membuf field
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler membuf field, process %d", addr, process_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Priority scheduler membuf field, process %d", addr, process_index);
                 return 0;
             }
             else if(ps_addr < PS_ENQUEUE_MMIO_OFFSET) {
                 // Priority scheduler dequeue field
                 uint64_t index = lite_executor->pst[process_index].index;
                 uint64_t value = ps_pop(&lite_executor->pschedulers[index]);
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler dequeue field, process %d", addr, value, process_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler dequeue field, process %d", addr, value, process_index);
                 return value;
             }
             else {
                 // Priority scheduler enqueue field
                 unsigned enqueue_vec_addr = ps_addr - PS_ENQUEUE_MMIO_OFFSET;
                 unsigned enqueue_index = enqueue_vec_addr / PS_ENQUEUE_MMIO_SIZE;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler enqueue field, process %d, queue %d", addr, process_index, enqueue_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Priority scheduler enqueue field, process %d, queue %d", addr, process_index, enqueue_index);
                 return 0;
             }
         }
@@ -74,35 +74,35 @@ static uint64_t riscv_lite_executor_read_64bit(RISCVLiteExecutor *lite_executor,
             unsigned ih_addr = process_addr - IPC_HANDLER_MMIO_OFFSET;
             if(ih_addr < IH_MEMBUF_MMIO_OFFSET) {
                 // IPC handler control field
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler control field, process %d", addr, process_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> IPC handler control field, process %d", addr, process_index);
                 return 0;
             }
             else if(ih_addr < IH_MESSAGE_POINTER_MMIO_OFFSET) {
                 // IPC handler membuf field
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler membuf field, process %d", addr, process_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> IPC handler membuf field, process %d", addr, process_index);
                 return 0;
             }
             else if(ih_addr < IH_BQ_MMIO_OFFSET) {
                 // IPC handler message pointer field
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler message pointer field, process %d", addr, process_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> IPC handler message pointer field, process %d", addr, process_index);
                 return 0;
             }
             else if(ih_addr < IH_RESERVED_MMIO_OFFSET) {
                 // IPC handler bq field
                 unsigned bq_vec_addr = ih_addr - IH_BQ_MMIO_OFFSET;
                 unsigned bq_index = bq_vec_addr / IH_BQ_MMIO_SIZE;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx-> IPC handler bq field, process %d, bq %d", addr, process_index, bq_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx-> IPC handler bq field, process %d, bq %d", addr, process_index, bq_index);
                 return 0;
             }
             else {
                 // IPC handler reserved area
-                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler reserved area, process %d", addr, process_index);
+                info_report("READ  LITE EXECUTOR: addr 0x%08lx -> IPC handler reserved area, process %d", addr, process_index);
                 return (uint64_t)(-1);
             }
         }
         else {
             // Process reserved area
-            info_report("READ LITE EXECUTOR: addr 0x%08lx -> Process reserved area, process %d", addr, process_index);
+            info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Process reserved area, process %d", addr, process_index);
             return (uint64_t)(-1);
         }
     }
@@ -112,20 +112,20 @@ static uint64_t riscv_lite_executor_read_64bit(RISCVLiteExecutor *lite_executor,
         if(eih_addr < EIH_ENQUEUE_MMIO_OFFSET) {
             // Extern interrupt handler control field
             unsigned control_addr = eih_addr;
-            info_report("READ LITE EXECUTOR: addr 0x%08lx -> Extern interrupt handler control field, inner addr 0x%04x", addr, control_addr);
+            info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Extern interrupt handler control field, inner addr 0x%04x", addr, control_addr);
             return 0;
         }
         else {
             // Extern interrupt handler enqueue field
             unsigned enqueue_vec_addr = eih_addr - EIH_ENQUEUE_MMIO_OFFSET;
             unsigned enqueue_index = enqueue_vec_addr / EIH_ENQUEUE_MMIO_SIZE;
-            info_report("READ LITE EXECUTOR: addr 0x%08lx -> Extern interrupt handler enqueue field, queue %d", addr, enqueue_index);
+            info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Extern interrupt handler enqueue field, queue %d", addr, enqueue_index);
             return 0;
         }
     }
     else {
         // Reserved area
-        info_report("READ LITE EXECUTOR: addr 0x%08lx -> Global reserved area", addr);
+        info_report("READ  LITE EXECUTOR: addr 0x%08lx -> Global reserved area", addr);
         return (uint64_t)(-1);
     }
     return 0;
@@ -235,10 +235,10 @@ static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned siz
         else if(lite_executor->expect_read_addr == addr) {
             // read high halfword
             lite_executor->expect_read_addr = (u_int64_t)(-1);
-            return lite_executor->read_buf & 0xffffffff00000000;
+            return (lite_executor->read_buf & 0xffffffff00000000) >> 32;
         }
         else {
-            info_report("READ LITE EXECUTOR: invalid read address %08lx", addr);
+            info_report("READ  LITE EXECUTOR: invalid read address %08lx", addr);
             return (uint64_t)(-1);
         }
     }
@@ -247,7 +247,7 @@ static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned siz
         return riscv_lite_executor_read_64bit(lite_executor, addr);
     }
     else {
-        info_report("READ LITE EXECUTOR: invalid read size %d", size);
+        info_report("READ  LITE EXECUTOR: invalid read size %d", size);
         return (uint64_t)(-1);
     }
 }

--- a/hw/ats/riscv_lite_executor.c
+++ b/hw/ats/riscv_lite_executor.c
@@ -28,9 +28,8 @@
 #include "hw/ats/riscv_lite_executor.h"
 #include "qemu/queue.h"
 
-static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned size)
+static uint64_t riscv_lite_executor_read_64bit(RISCVLiteExecutor *lite_executor, hwaddr addr)
 {
-    RISCVLiteExecutor *lite_executor = opaque;
     if(addr < EXT_INTR_HANDLER_MMIO_OFFSET) {
         // Process area
         unsigned process_vec_addr = addr;
@@ -47,26 +46,26 @@ static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned siz
             if(ps_addr < PS_MEMBUF_MMIO_OFFSET) {
                 // Priority scheduler control field
                 unsigned control_addr = ps_addr;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Priority scheduler control field, process %d, inner addr 0x%04x", addr, size, process_index, control_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler control field, process %d, inner addr 0x%04x", addr, process_index, control_addr);
                 return 0;
             }
             else if(ps_addr < PS_DEQUEUE_MMIO_OFFSET) {
                 // Priority scheduler membuf field
-                unsigned membuf_addr = ps_addr - PS_MEMBUF_MMIO_OFFSET;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Priority scheduler membuf field, process %d, inner addr 0x%04x", addr, size, process_index, membuf_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler membuf field, process %d", addr, process_index);
                 return 0;
             }
             else if(ps_addr < PS_ENQUEUE_MMIO_OFFSET) {
                 // Priority scheduler dequeue field
                 uint64_t index = lite_executor->pst[process_index].index;
-                return ps_pop(&lite_executor->pschedulers[index]);
+                uint64_t value = ps_pop(&lite_executor->pschedulers[index]);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler dequeue field, process %d", addr, value, process_index);
+                return value;
             }
             else {
                 // Priority scheduler enqueue field
                 unsigned enqueue_vec_addr = ps_addr - PS_ENQUEUE_MMIO_OFFSET;
                 unsigned enqueue_index = enqueue_vec_addr / PS_ENQUEUE_MMIO_SIZE;
-                unsigned enqueue_addr = enqueue_vec_addr % PS_ENQUEUE_MMIO_SIZE;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Priority scheduler enqueue field, process %d, queue %d, inner addr 0x%04x", addr, size, process_index, enqueue_index, enqueue_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler enqueue field, process %d, queue %d", addr, process_index, enqueue_index);
                 return 0;
             }
         }
@@ -75,39 +74,35 @@ static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned siz
             unsigned ih_addr = process_addr - IPC_HANDLER_MMIO_OFFSET;
             if(ih_addr < IH_MEMBUF_MMIO_OFFSET) {
                 // IPC handler control field
-                unsigned control_addr = ih_addr;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> IPC handler control field, process %d, inner addr 0x%04x", addr, size, process_index, control_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler control field, process %d", addr, process_index);
                 return 0;
             }
             else if(ih_addr < IH_MESSAGE_POINTER_MMIO_OFFSET) {
                 // IPC handler membuf field
-                unsigned membuf_addr = ih_addr - IH_MEMBUF_MMIO_OFFSET;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> IPC handler membuf field, process %d, inner addr 0x%04x", addr, size, process_index, membuf_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler membuf field, process %d", addr, process_index);
                 return 0;
             }
             else if(ih_addr < IH_BQ_MMIO_OFFSET) {
                 // IPC handler message pointer field
-                unsigned message_pointer_addr = ih_addr - IH_MESSAGE_POINTER_MMIO_OFFSET;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> IPC handler message pointer field, process %d, inner addr 0x%04x", addr, size, process_index, message_pointer_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler message pointer field, process %d", addr, process_index);
                 return 0;
             }
             else if(ih_addr < IH_RESERVED_MMIO_OFFSET) {
                 // IPC handler bq field
                 unsigned bq_vec_addr = ih_addr - IH_BQ_MMIO_OFFSET;
                 unsigned bq_index = bq_vec_addr / IH_BQ_MMIO_SIZE;
-                unsigned bq_addr = bq_vec_addr % IH_BQ_MMIO_SIZE;
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> IPC handler bq field, process %d, bq %d, inner addr 0x%04x", addr, size, process_index, bq_index, bq_addr);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx-> IPC handler bq field, process %d, bq %d", addr, process_index, bq_index);
                 return 0;
             }
             else {
                 // IPC handler reserved area
-                info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> IPC handler reserved area, process %d", addr, size, process_index);
+                info_report("READ LITE EXECUTOR: addr 0x%08lx -> IPC handler reserved area, process %d", addr, process_index);
                 return (uint64_t)(-1);
             }
         }
         else {
             // Process reserved area
-            info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Process reserved area, process %d", addr, size, process_index);
+            info_report("READ LITE EXECUTOR: addr 0x%08lx -> Process reserved area, process %d", addr, process_index);
             return (uint64_t)(-1);
         }
     }
@@ -117,30 +112,27 @@ static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned siz
         if(eih_addr < EIH_ENQUEUE_MMIO_OFFSET) {
             // Extern interrupt handler control field
             unsigned control_addr = eih_addr;
-            info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Extern interrupt handler control field, inner addr 0x%04x", addr, size, control_addr);
+            info_report("READ LITE EXECUTOR: addr 0x%08lx -> Extern interrupt handler control field, inner addr 0x%04x", addr, control_addr);
             return 0;
         }
         else {
             // Extern interrupt handler enqueue field
             unsigned enqueue_vec_addr = eih_addr - EIH_ENQUEUE_MMIO_OFFSET;
             unsigned enqueue_index = enqueue_vec_addr / EIH_ENQUEUE_MMIO_SIZE;
-            unsigned enqueue_addr = enqueue_vec_addr % EIH_ENQUEUE_MMIO_SIZE;
-            info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Extern interrupt handler enqueue field, queue %d, inner addr 0x%04x", addr, size, enqueue_index, enqueue_addr);
+            info_report("READ LITE EXECUTOR: addr 0x%08lx -> Extern interrupt handler enqueue field, queue %d", addr, enqueue_index);
             return 0;
         }
     }
     else {
         // Reserved area
-        info_report("READ LITE EXECUTOR: addr 0x%08lx, size 0x%x -> Global reserved area", addr, size);
+        info_report("READ LITE EXECUTOR: addr 0x%08lx -> Global reserved area", addr);
         return (uint64_t)(-1);
     }
     return 0;
 }
 
-static void riscv_lite_executor_write(void *opaque, hwaddr addr, uint64_t value,
-                              unsigned size)
+static void riscv_lite_executor_write_64bit(RISCVLiteExecutor *lite_executor, hwaddr addr, uint64_t value)
 {
-    RISCVLiteExecutor *lite_executor = opaque;
     if(addr < EXT_INTR_HANDLER_MMIO_OFFSET) {
         // Process area
         unsigned process_vec_addr = addr;
@@ -157,28 +149,24 @@ static void riscv_lite_executor_write(void *opaque, hwaddr addr, uint64_t value,
             if(ps_addr < PS_MEMBUF_MMIO_OFFSET) {
                 // Priority scheduler control field
                 unsigned control_addr = ps_addr;
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Priority scheduler control field, process %d, inner addr 0x%04x", addr, size, value, process_index, control_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler control field, process %d, inner addr 0x%04x", addr, value, process_index, control_addr);
             }
             else if(ps_addr < PS_DEQUEUE_MMIO_OFFSET) {
                 // Priority scheduler membuf field
-                unsigned membuf_addr = ps_addr - PS_MEMBUF_MMIO_OFFSET;
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Priority scheduler membuf field, process %d, inner addr 0x%04x", addr, size, value, process_index, membuf_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler membuf field, process %d", addr, value, process_index);
             }
             else if(ps_addr < PS_ENQUEUE_MMIO_OFFSET) {
                 // Priority scheduler dequeue field
-                unsigned dequeue_addr = ps_addr - PS_DEQUEUE_MMIO_OFFSET;
-                // code with `process_index`, `dequeue_addr` and `size`
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Priority scheduler dequeue field, process %d, inner addr 0x%04x", addr, size, value, process_index, dequeue_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler dequeue field, process %d", addr, value, process_index);
             }
             else {
                 // Priority scheduler enqueue field
                 unsigned enqueue_vec_addr = ps_addr - PS_ENQUEUE_MMIO_OFFSET;
                 unsigned enqueue_index = enqueue_vec_addr / PS_ENQUEUE_MMIO_SIZE;
-                unsigned enqueue_addr = enqueue_vec_addr % PS_ENQUEUE_MMIO_SIZE;
                 assert(enqueue_index < MAX_TASK_QUEUE);
                 uint64_t index = lite_executor->pst[process_index].index;
                 ps_push(&lite_executor->pschedulers[index], enqueue_index, value);
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Priority scheduler enqueue field, process %d, queue %d, inner addr 0x%04x", addr, size, value, process_index, enqueue_index, enqueue_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Priority scheduler enqueue field, process %d, queue %d", addr, value, process_index, enqueue_index);
             }
         }
         else if(process_addr < PROCESS_RESERVED_MMIO_OFFSET) {
@@ -186,34 +174,30 @@ static void riscv_lite_executor_write(void *opaque, hwaddr addr, uint64_t value,
             unsigned ih_addr = process_addr - IPC_HANDLER_MMIO_OFFSET;
             if(ih_addr < IH_MEMBUF_MMIO_OFFSET) {
                 // IPC handler control field
-                unsigned control_addr = ih_addr;
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> IPC handler control field, process %d, inner addr 0x%04x", addr, size, value, process_index, control_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> IPC handler control field, process %d", addr, value, process_index);
             }
             else if(ih_addr < IH_MESSAGE_POINTER_MMIO_OFFSET) {
                 // IPC handler membuf field
-                unsigned membuf_addr = ih_addr - IH_MEMBUF_MMIO_OFFSET;
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> IPC handler membuf field, process %d, inner addr 0x%04x", addr, size, value, process_index, membuf_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> IPC handler membuf field, process %d", addr, value, process_index);
             }
             else if(ih_addr < IH_BQ_MMIO_OFFSET) {
                 // IPC handler message pointer field
-                unsigned message_pointer_addr = ih_addr - IH_MESSAGE_POINTER_MMIO_OFFSET;
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> IPC handler message pointer field, process %d, inner addr 0x%04x", addr, size, value, process_index, message_pointer_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> IPC handler message pointer field, process %d", addr, value, process_index);
             }
             else if(ih_addr < IH_RESERVED_MMIO_OFFSET) {
                 // IPC handler bq field
                 unsigned bq_vec_addr = ih_addr - IH_BQ_MMIO_OFFSET;
                 unsigned bq_index = bq_vec_addr / IH_BQ_MMIO_SIZE;
-                unsigned bq_addr = bq_vec_addr % IH_BQ_MMIO_SIZE;
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> IPC handler bq field, process %d, bq %d, inner addr 0x%04x", addr, size, value, process_index, bq_index, bq_addr);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> IPC handler bq field, process %d, bq %d", addr, value, process_index, bq_index);
             }
             else {
                 // IPC handler reserved area
-                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> IPC handler reserved area, process %d", addr, size, value, process_index);
+                info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> IPC handler reserved area, process %d", addr, value, process_index);
             }
         }
         else {
             // Process reserved area
-            info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Process reserved area, process %d", addr, size, value, process_index);
+            info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Process reserved area, process %d", addr, value, process_index);
         }
     }
     else if(addr < GLOBAL_RESERVED_MMIO_OFFSET) {
@@ -222,20 +206,77 @@ static void riscv_lite_executor_write(void *opaque, hwaddr addr, uint64_t value,
         if(eih_addr < EIH_ENQUEUE_MMIO_OFFSET) {
             // Extern interrupt handler control field
             unsigned control_addr = eih_addr;
-            info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Extern interrupt handler control field, inner addr 0x%04x", addr, size, value, control_addr);
+            info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Extern interrupt handler control field, inner addr 0x%04x", addr, value, control_addr);
         }
         else {
             // Extern interrupt handler enqueue field
             unsigned enqueue_vec_addr = eih_addr - EIH_ENQUEUE_MMIO_OFFSET;
             unsigned enqueue_index = enqueue_vec_addr / EIH_ENQUEUE_MMIO_SIZE;
-            unsigned enqueue_addr = enqueue_vec_addr % EIH_ENQUEUE_MMIO_SIZE;
             queue_push(&lite_executor->eihqs[enqueue_index], value);
-            info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Extern interrupt handler enqueue field, queue %d, inner addr 0x%04x", addr, size, value, enqueue_index, enqueue_addr);
+            info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Extern interrupt handler enqueue field, queue %d", addr, value, enqueue_index);
         }
     }
     else {
         // Reserved area
-        info_report("WRITE LITE EXECUTOR: addr 0x%08lx, size 0x%x, value 0x%08lx -> Global reserved area", addr, size, value);
+        info_report("WRITE LITE EXECUTOR: addr 0x%08lx, value 0x%016lx -> Global reserved area", addr, value);
+    }
+}
+
+static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned size) {
+    RISCVLiteExecutor *lite_executor = opaque;
+    if(size == 4) {
+        if(lite_executor->expect_read_addr == (u_int64_t)(-1)) {
+            // read low halfword
+            assert((addr & 0x7) == 0);
+            lite_executor->expect_read_addr = addr + 4;
+            lite_executor->read_buf = riscv_lite_executor_read_64bit(lite_executor, addr);
+            return lite_executor->read_buf & 0xffffffff;
+        }
+        else if(lite_executor->expect_read_addr == addr) {
+            // read high halfword
+            lite_executor->expect_read_addr = (u_int64_t)(-1);
+            return lite_executor->read_buf & 0xffffffff00000000;
+        }
+        else {
+            info_report("READ LITE EXECUTOR: invalid read address %08lx", addr);
+            return (uint64_t)(-1);
+        }
+    }
+    else if(size == 8) {
+        assert((addr & 0x7) == 0);
+        return riscv_lite_executor_read_64bit(lite_executor, addr);
+    }
+    else {
+        info_report("READ LITE EXECUTOR: invalid read size %d", size);
+        return (uint64_t)(-1);
+    }
+}
+
+static void riscv_lite_executor_write(void *opaque, hwaddr addr, uint64_t value, unsigned size) {
+    RISCVLiteExecutor *lite_executor = opaque;
+    if(size == 4) {
+        if(lite_executor->expect_write_addr == (u_int64_t)(-1)) {
+            // write low halfword
+            assert((addr & 0x7) == 0);
+            lite_executor->expect_write_addr = addr + 4;
+            lite_executor->write_buf = value;
+        }
+        else if(lite_executor->expect_write_addr == addr) {
+            // write high halfword
+            lite_executor->expect_write_addr = (u_int64_t)(-1);
+            lite_executor->write_buf = lite_executor->write_buf | (value << 32);
+            riscv_lite_executor_write_64bit(lite_executor, addr - 4, lite_executor->write_buf);
+        }
+        else {
+            info_report("WRITE LITE EXECUTOR: invalid write address %08lx", addr);
+        }
+    }
+    else if(size == 8) {
+        assert((addr & 0x7) == 0);
+        riscv_lite_executor_write_64bit(lite_executor, addr, value);
+    }
+    else {
+        info_report("WRITE LITE EXECUTOR: invalid write size %d", size);
     }
 }
 
@@ -261,7 +302,7 @@ static void riscv_lite_executor_irq_request(void *opaque, int irq, int level)
     if (handler != 0) {
         uint64_t index = lite_executor->pst[0].index;
         ps_push(&lite_executor->pschedulers[index], 0, handler);
-        info_report("external interrupt handler 0x%08lx", handler);
+        info_report("external interrupt handler 0x%016lx", handler);
     }
 
     // 外部中断到来后的操作，待实现
@@ -301,6 +342,10 @@ static void riscv_lite_executor_realize(DeviceState *dev, Error **errp)
     for(i = 0; i < MAX_ONLINE_STRUCT_GROUP; i++) {
         ps_init(&lite_executor->pschedulers[i]);
     }
+
+    // init rw expect addr, -1 indicates no expect address
+    lite_executor->expect_read_addr = (uint64_t)(-1);
+    lite_executor->expect_write_addr = (uint64_t)(-1);
 
     //注册GPIO端口，参考sifive_plic.c:380..387
     {

--- a/include/hw/ats/riscv_lite_executor.h
+++ b/include/hw/ats/riscv_lite_executor.h
@@ -110,6 +110,11 @@ typedef struct RISCVLiteExecutor
     PriorityScheduler *pschedulers;
     // external interrupt handler queues
     Queue *eihqs;
+    // rw buffer? convert 32bit read to 64bit read
+    uint64_t read_buf;
+    uint64_t expect_read_addr; // -1 indicates no expect address
+    uint64_t write_buf;
+    uint64_t expect_write_addr; // -1 indicates no expect address
 
     /* config */
     uint32_t num_sources; //中断处理相关，中断源的数目？


### PR DESCRIPTION
在lite executor的MMIO读写函数中增加了32位转64位的代码，使得lite executor可以处理`size = 4`和`size = 8`两种读写方式。当前计算机系统使用的`size = 4`的读写方式已经进行了测试，结果无误（见下图）。

新的读写函数还能通过`assert`确保访问地址对齐。

此外，还优化了测试输出，取消了`size`属性的打印（因为两种读写方式都会被新的读写函数处理成`size = 8`再进入原有的读写函数），取消了8字节字段的`inner addr`属性的打印（大于8字节的字段则保留该属性）。

![image](https://github.com/ATS-INTC/qemu/assets/114291027/2003e170-d3ee-41b3-b2cf-1b6ee891fb6f)