### PR TITLE
注释了一句会刷屏的打印代码

### DIFF
--- a/hw/ats/riscv_lite_executor.c
+++ b/hw/ats/riscv_lite_executor.c
@@ -59,7 +59,7 @@ static uint64_t riscv_lite_executor_read(void *opaque, hwaddr addr, unsigned siz
             else if(ps_addr < PS_ENQUEUE_MMIO_OFFSET) {
                 // Priority scheduler dequeue field
                 uint64_t index = lite_executor->pst[process_index].index;
-                info_report(" READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler dequeue field, process %d", addr, process_index);
+                // info_report(" READ LITE EXECUTOR: addr 0x%08lx -> Priority scheduler dequeue field, process %d", addr, process_index);
                 return ps_pop(&lite_executor->pschedulers[index]);
             }
             else {


### PR DESCRIPTION
注释了一句在`ats-intc-executor`的运行过程中，会刷屏的打印代码。